### PR TITLE
Add ability to call check_and_force_update_vehicles function for just one specific vehicle.

### DIFF
--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -97,23 +97,26 @@ class VehicleManager:
             _LOGGER.debug(f"{DOMAIN} - Vehicle Disabled, skipping.")
 
     def check_and_force_update_vehicles(self, force_refresh_interval: int) -> None:
+        for vehicle_id in self.vehicles.keys():
+            self.check_and_force_update_vehicle(force_refresh_interval, vehicle_id)
+
+    def check_and_force_update_vehicle(self, force_refresh_interval: int, vehicle_id: str) -> None:
         # Force refresh only if current data is older than the value bassed in seconds.
         # Otherwise runs a cached update.
         started_at_utc: dt = dt.datetime.now(pytz.utc)
-        for vehicle_id in self.vehicles.keys():
-            vehicle = self.get_vehicle(vehicle_id)
-            if vehicle.last_updated_at is not None:
-                _LOGGER.debug(
-                    f"{DOMAIN} - Time differential in seconds: {(started_at_utc - vehicle.last_updated_at).total_seconds()}"  # noqa
-                )
-                if (
-                    started_at_utc - vehicle.last_updated_at
-                ).total_seconds() > force_refresh_interval:
-                    self.force_refresh_vehicle_state(vehicle_id)
-                else:
-                    self.update_vehicle_with_cached_state(vehicle_id)
+        vehicle = self.get_vehicle(vehicle_id)
+        if vehicle.last_updated_at is not None:
+            _LOGGER.debug(
+                f"{DOMAIN} - Time differential in seconds: {(started_at_utc - vehicle.last_updated_at).total_seconds()}"  # noqa
+            )
+            if (
+                started_at_utc - vehicle.last_updated_at
+            ).total_seconds() > force_refresh_interval:
+                self.force_refresh_vehicle_state(vehicle_id)
             else:
                 self.update_vehicle_with_cached_state(vehicle_id)
+        else:
+            self.update_vehicle_with_cached_state(vehicle_id)
 
     def force_refresh_all_vehicles_states(self) -> None:
         for vehicle_id in self.vehicles.keys():


### PR DESCRIPTION
Hello,
This PR adds the ability to call the check_and_force_update_vehicles function for just one specific vehicle.
The reason this is a neccessary feature is that if you have multiple vehicles connected to your account and one of them goes into energy saver mode so that it does not respond to force update requests anymore, these requests fail with an APIError which breaks the vehicles loop so that later vehicles are not queried at all even though they would respond. With the new funtion it is possible to query the vehicles from isolated try blocks so that one failing vehicle does not cause all others to fail too.
Best regards,
Triple-S